### PR TITLE
Fix S3 Bucket Naming Convention

### DIFF
--- a/deployAllLayers
+++ b/deployAllLayers
@@ -185,7 +185,8 @@ if [ "$DESTROY_MODE" = true ]; then
     
     # Empty S3 bucket before destroying BaseInfra
     echo "Emptying S3 bucket..."
-    S3_BUCKET="tak-${STACK_NAME,,}-baseinfra-${REGION}-env-config"
+    ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+    S3_BUCKET="tak-${STACK_NAME,,}-baseinfra-${REGION}-${ACCOUNT_ID}-config"
     aws s3 rm "s3://$S3_BUCKET" --recursive || true
     
     # Destroy BaseInfra
@@ -218,7 +219,8 @@ else
     
     # Upload configuration files to S3
     echo "Uploading configuration files to S3..."
-    S3_BUCKET="tak-${STACK_NAME,,}-baseinfra-${REGION}-env-config"
+    ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+    S3_BUCKET="tak-${STACK_NAME,,}-baseinfra-${REGION}-${ACCOUNT_ID}-config"
     for config_file in "authentik-config.env" "takserver-config.env" "cloudtak-config.env"; do
         if [ -f "$INITIAL_DIR/$config_file" ]; then
             echo "Uploading existing $config_file"


### PR DESCRIPTION
## Fix S3 Bucket Naming Convention

### Changes
- Updated S3 bucket name format to include AWS account ID
- Changed from `tak-{envName}-baseinfra-{region}-env-config` to `tak-{envName}-baseinfra-{region}-{account}-config`
- Added `aws sts get-caller-identity` call to retrieve account ID dynamically

### Files Modified
- `deployAllLayers` - Updated bucket name references in both deploy and destroy modes

### Testing
- [ ] Verify bucket name matches infrastructure deployment
- [ ] Test both deployment and destruction workflows
