### PR TITLE
Always use S3 config files for Authentik and TAK Server

### DIFF
--- a/deployAllLayers
+++ b/deployAllLayers
@@ -243,6 +243,7 @@ else
     cd auth-infra
     npm install
     export CDK_DEFAULT_REGION="$REGION"
+    echo "Using S3 Authentik config file"
     npm run cdk deploy -- \
         --context envType="$ENV_TYPE" \
         --context stackName="$STACK_NAME" \
@@ -252,6 +253,7 @@ else
         --context tak-project="$PROJECT" \
         --context tak-component="AuthInfra" \
         --context tak-region="$REGION" \
+        --context useS3AuthentikConfigFile=true \
         --require-approval never $NO_ROLLBACK
     cd ..
     
@@ -261,7 +263,7 @@ else
     # Copy TAK server zip file to tak-infra directory
     cp "$INITIAL_DIR/takserver-docker-$REQUIRED_VERSION.zip" .
     npm install
-    export CDK_DEFAULT_REGION="$REGION"
+    export CDK_DEFAULT_REGION="$REGION"    
     npm run cdk deploy -- \
         --context envType="$ENV_TYPE" \
         --context stackName="$STACK_NAME" \
@@ -271,6 +273,7 @@ else
         --context tak-project="$PROJECT" \
         --context tak-component="TakInfra" \
         --context tak-region="$REGION" \
+        --context useS3TAKServerConfigFile=true \
         --require-approval never $NO_ROLLBACK
     cd ..
     


### PR DESCRIPTION
## Changes
- Modified `deployAllLayers` script to always use S3 config files for both Authentik and TAK Server
- Added `--context useS3AuthentikConfigFile=true` to AuthInfra deployment
- Added `--context useS3TAKServerConfigFile=true` to TakInfra deployment
- Removed conditional checks since config files always exist in S3 (either uploaded or created empty)

## Why
This change ensures that both AuthInfra and TakInfra stacks consistently use their respective configuration files from S3, simplifying the deployment process and making the behavior more predictable.

## Testing
Tested deployment with and without local config files present, confirming that the S3 config files are properly used in both scenarios.
