### PR TITLE
Enable S3 configuration file for CloudTAK deployment

### DIFF
--- a/deployAllLayers
+++ b/deployAllLayers
@@ -315,6 +315,7 @@ else
             --context tak-project="$PROJECT" \
             --context tak-component="CloudTAK" \
             --context tak-region="$REGION" \
+            --context useS3CloudTAKConfigFile=true \
             --require-approval never $NO_ROLLBACK
         cd ../..
     fi


### PR DESCRIPTION
## Description
Added the `useS3CloudTAKConfigFile=true` context parameter to the CloudTAK deployment command to ensure it uses the configuration file stored in S3 instead of looking for a local configuration file.

## Motivation
This change ensures CloudTAK follows the same configuration pattern as AuthInfra and TakInfra components, which already use S3-stored configuration files. This provides a consistent approach to configuration management across all TAK components.

## Changes
- Added `--context useS3CloudTAKConfigFile=true` parameter to the CloudTAK CDK deployment command

## Testing
- Verified that CloudTAK deployment successfully reads configuration from the S3 bucket
- Confirmed that the deployment process completes without errors

